### PR TITLE
Use_Signal_Handler

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ LOCAL_SHELL_TEST	:= sh/test.sh
 
 # Debug flags
 ifeq ("$(VERSION_MODE)", "DEBUG")
-	DEBUG_INFO := -g -Wall
+	DEBUG_INFO := -g -Wall -fsanitize=address
 else
 	DEBUG_INFO :=
 endif

--- a/config.xml
+++ b/config.xml
@@ -49,6 +49,11 @@
             lib_name="pthread"
             package="libc6-dev"
         />
+        <Binary_Utilities
+            type="APT_package"
+            lib_name=""
+            package="binutils"
+        />
     </deps>
 
     <!-- Tests -->

--- a/config.xml
+++ b/config.xml
@@ -37,13 +37,6 @@
 
     <!-- Dependencies -->
     <deps Dest="deps">
-        <C_Signal_Handler
-            version_major="1"
-            version_minor="0"
-            version_mode="DEBUG"
-            local_path="~/Desktop/scripts/C/C_Signal_Handler"
-            URL="https://github.com/JonMS95/C_Signal_Handler"
-        />
         <Posix_Threads
             type="APT_package"
             lib_name="pthread"

--- a/config.xml
+++ b/config.xml
@@ -29,7 +29,7 @@
     <!-- Common shell files location -->
     <Common_shell_files
         version_major="1"
-        version_minor="3"
+        version_minor="4"
         version_mode="RELEASE"
         local_path="~/C_Common_shell_files"
         URL="https://github.com/JonMS95/C_Common_shell_files"

--- a/config.xml
+++ b/config.xml
@@ -2,8 +2,8 @@
 <config>
     <Project_data
         version_major="1"
-        version_minor="0"
-        version_mode="RELEASE"
+        version_minor="1"
+        version_mode="DEBUG"
         URL="https://github.com/JonMS95/C_Mutex_Guard"
         type="library"
         language="C"
@@ -13,6 +13,10 @@
     <Directories>
         <lib/>
         <API/>
+        <deps>
+            <lib/>
+            <inc/>
+        </deps>
         <test>
             <deps>
                 <inc/>
@@ -32,7 +36,14 @@
     />
 
     <!-- Dependencies -->
-    <deps Dest="">
+    <deps Dest="deps">
+        <C_Signal_Handler
+            version_major="1"
+            version_minor="0"
+            version_mode="DEBUG"
+            local_path="~/Desktop/scripts/C/C_Signal_Handler"
+            URL="https://github.com/JonMS95/C_Signal_Handler"
+        />
         <Posix_Threads
             type="APT_package"
             lib_name="pthread"
@@ -60,15 +71,22 @@
             />
             <C_Severity_Log
                 version_major="2"
-                version_minor="1"
-                version_mode="RELEASE"
+                version_minor="3"
+                version_mode="DEBUG"
                 URL="https://github.com/JonMS95/C_Severity_Log"
-                local_path="~/C_Severity_Log"
+                local_path="~/Desktop/scripts/C/C_Severity_Log"
+            />
+            <C_Signal_Handler
+                version_major="1"
+                version_minor="0"
+                version_mode="DEBUG"
+                local_path="~/Desktop/scripts/C/C_Signal_Handler"
+                URL="https://github.com/JonMS95/C_Signal_Handler"
             />
             <C_Mutex_Guard
                 version_major="1"
-                version_minor="0"
-                version_mode="RELEASE"
+                version_minor="1"
+                version_mode="DEBUG"
                 local_path="."
                 URL="https://github.com/JonMS95/C_Mutex_Guard"
             />

--- a/src/MutexGuard.c
+++ b/src/MutexGuard.c
@@ -860,6 +860,8 @@ int MutexGuardLock(MTX_GRD* p_mutex_guard, void* restrict address, const uint64_
 
     mutex_guard_lock_error_code = 0;
 
+    pthread_mutex_lock(&p_mutex_guard->ctrl_mutex);
+
     MutexGuardStoreNewAddress(p_mutex_guard, address);
 
     p_mutex_guard->mutex_acq_location.thread_id = pthread_self();
@@ -871,6 +873,8 @@ int MutexGuardLock(MTX_GRD* p_mutex_guard, void* restrict address, const uint64_
 
     if(verbosity_level & MTX_GRD_VERBOSITY_BT)
         MutexGuardShowBacktrace(&p_mutex_guard->mutex, true);
+
+    pthread_mutex_unlock(&p_mutex_guard->ctrl_mutex);
 
     return ret_lock;
 }

--- a/src/MutexGuard.c
+++ b/src/MutexGuard.c
@@ -484,6 +484,20 @@ static int MutexGuardDestroyCtrlMutex(MTX_GRD* restrict p_mutex_guard, const boo
     MTX_GRD_CTRL_MUTEX_CONTROL_FLOW(pthread_mutex_destroy(&p_mutex_guard->ctrl_mutex));
 }
 
+/// @brief MutexGuardAttrInit function wrapper.
+/// @param p_mutex_guard Pointer to mutex guard structure.
+/// @param mutex_type Mutex type (NORMAL, ERRORCHECK, RECURSIVE, DEFAULT).
+/// @param priority Mutex priority (NONE, INHERIT, PROTECT).
+/// @param proc_sharing Share mutex with other processes (PRIVATE, SHARED).
+/// @return Pointer to mutex guard structure if succeeded, NULL otherwise.
+MTX_GRD* MutexGuardAttrInitAddr(MTX_GRD* restrict p_mutex_guard ,
+                                const int mutex_type            , 
+                                const int priority              ,
+                                const int proc_sharing          )
+{
+    return (MutexGuardAttrInit(p_mutex_guard, mutex_type, priority, proc_sharing) ? NULL : p_mutex_guard);
+}
+
 /// @brief Initializes mutex.
 /// @param p_mutex_guard Pointer to mutex containing mutex guard structure.
 /// @return 0 if succeeded, != 0 otherwise.
@@ -512,6 +526,14 @@ int MutexGuardInit(MTX_GRD* restrict p_mutex_guard)
     }
 
     return 0;
+}
+
+/// @brief Initializes mutex.
+/// @param p_mutex_guard Pointer to mutex containing mutex guard structure.
+/// @return 0 if succeeded, != 0 otherwise.
+MTX_GRD* MutexGuardInitAddr(MTX_GRD* restrict p_mutex_guard)
+{
+    return (MutexGuardInit(p_mutex_guard) ? NULL : p_mutex_guard);
 }
 
 /// @brief Stores a new lock address.
@@ -1019,6 +1041,14 @@ int MutexGuardLock(MTX_GRD* p_mutex_guard, void* restrict address, const uint64_
     return ret_lock;
 }
 
+C_MUTEX_GUARD_API MTX_GRD* MutexGuardLockAddr(  MTX_GRD* restrict p_mutex_guard ,
+                                                void* restrict address          ,
+                                                const uint64_t timeout_ns       ,
+                                                const int lock_type             )
+{
+    return (MutexGuardLock(p_mutex_guard, address, timeout_ns, lock_type) ? NULL : p_mutex_guard);
+}
+
 /// @brief Gets base address of the executable in which a mutex lock error has happened.
 /// @return 0 if succeeded, < 0 otherwise.
 static size_t MutexGuardGetExecutableBaseddress(void)
@@ -1158,7 +1188,7 @@ static int MutexGuardPrintFileAndLineFromAddr(  const void* restrict addr       
 
 /// @brief Returns address within the program of line in which the current function was called. Meant to be used in macros.
 /// @return Current function calling address.
-C_MUTEX_GUARD_NINLINE void* MutexGuardGetFuncRetAddr(void)
+C_MUTEX_GUARD_NOINLINE void* MutexGuardGetFuncRetAddr(void)
 {
     return __builtin_return_address(0); 
 }

--- a/src/MutexGuard.c
+++ b/src/MutexGuard.c
@@ -1267,8 +1267,10 @@ int MutexGuardDestroy(MTX_GRD* restrict p_mtx_grd)
     }
 
     if(MutexGuardLockCtrlMutex(p_mtx_grd, false))
+    {
         mutex_guard_errno = MTX_GRD_ERR_INTERNAL_MUTEX_ERROR;
         return -2;
+    }
 
     int original_lock_counter = p_mtx_grd->lock_counter;
 

--- a/src/MutexGuard_api.h
+++ b/src/MutexGuard_api.h
@@ -42,6 +42,7 @@ typedef struct C_MUTEX_GUARD_ALIGNED
     pthread_mutexattr_t     mutex_attr;
     MTX_GRD_ACQ_LOCATION    mutex_acq_location;
     unsigned long long      lock_counter;
+    pthread_mutex_t         ctrl_mutex;
     void*                   additional_data;
 } MTX_GRD;
 

--- a/src/MutexGuard_api.h
+++ b/src/MutexGuard_api.h
@@ -9,6 +9,7 @@ extern "C" {
 
 #include <stdint.h>
 #include <pthread.h>
+#include <stdbool.h>
 
 /*****************************************/
 
@@ -153,6 +154,10 @@ C_MUTEX_GUARD_API const char* MutexGuardGetErrorString(const int error_code);
 /// @brief Prints error.
 /// @param custom_error_msg String to be copied to.
 C_MUTEX_GUARD_API void MutexGuardPrintError(const char* restrict custom_error_msg);
+
+/// @brief Tells whether should the program be terminated on internal mutex management error.
+/// @param mode Target mode (T/F). True -> ends program forcefully on error. False -> keeps trying.
+C_MUTEX_GUARD_API void MutexGuardSetInternalErrMode(const bool mode);
 
 /// @brief Sets verbosity level.
 /// @param target_verbosity_level Target verbosity level (silent, lock errors, backtrace or both). 

--- a/src/MutexGuard_api.h
+++ b/src/MutexGuard_api.h
@@ -69,6 +69,16 @@ typedef enum
     MTX_GRD_VERBOSITY_MAX       = MTX_GRD_VERBOSITY_ALL     ,
 } MTX_GRD_VERBOSITY_LEVEL;
 
+/// @brief Available internal error management modes.
+typedef enum
+{
+    MTX_GRD_INT_ERR_MGMT_KEEP_TRYING    = 0                                     ,
+    MTX_GRD_INT_ERR_MGMT_ABORT_ON_ERROR                                         ,
+    MTX_GRD_INT_ERR_MGMT_FORCE_ONE_SHOT                                         ,
+    MTX_GRD_INT_ERR_MGMT_MIN            = MTX_GRD_INT_ERR_MGMT_KEEP_TRYING      ,
+    MTX_GRD_INT_ERR_MGMT_MAX            = MTX_GRD_INT_ERR_MGMT_FORCE_ONE_SHOT   ,
+} MTX_GRD_INT_ERR_MGMT;
+
 /*****************************************/
 
 /**************** Macros *****************/
@@ -155,9 +165,13 @@ C_MUTEX_GUARD_API const char* MutexGuardGetErrorString(const int error_code);
 /// @param custom_error_msg String to be copied to.
 C_MUTEX_GUARD_API void MutexGuardPrintError(const char* restrict custom_error_msg);
 
-/// @brief Tells whether should the program be terminated on internal mutex management error.
-/// @param mode Target mode (T/F). True -> ends program forcefully on error. False -> keeps trying.
-C_MUTEX_GUARD_API void MutexGuardSetInternalErrMode(const bool mode);
+/// @brief Establishes how should the program behave on internal mutex management error.
+/// @param mode Target mode (check available values on MTX_GRD_INT_ERR_MGMT).
+C_MUTEX_GUARD_API int MutexGuardSetInternalErrMode(const MTX_GRD_INT_ERR_MGMT mgmt_mode);
+
+/// @brief Retrieves current internal error management mode.
+/// @return Currently assigned internal error management mode.
+C_MUTEX_GUARD_API MTX_GRD_INT_ERR_MGMT MutexGuardGetInternalErrMode(void);
 
 /// @brief Sets verbosity level.
 /// @param target_verbosity_level Target verbosity level (silent, lock errors, backtrace or both). 

--- a/src/MutexGuard_api.h
+++ b/src/MutexGuard_api.h
@@ -16,8 +16,7 @@ extern "C" {
 /*********** Define statements ***********/
 
 #define C_MUTEX_GUARD_API                   __attribute__((visibility("default")))
-#define C_MUTEX_GUARD_AINLINE               inline __attribute__((always_inline))
-#define C_MUTEX_GUARD_NINLINE               __attribute__((noinline))
+#define C_MUTEX_GUARD_NOINLINE              __attribute__((noinline))
 #define C_MUTEX_GUARD_ALIGNED               __attribute__((aligned(sizeof(size_t))))
 #define C_MUTEX_GUARD_DESTROY_ATTR_CLEANUP  __attribute__((cleanup(MutexGuardDestroyAttrCleanup)))
 #define C_MUTEX_GUARD_DESTROY_CLEANUP       __attribute__((cleanup(MutexGuardDestroyMutexCleanup)))
@@ -199,12 +198,10 @@ C_MUTEX_GUARD_API int MutexGuardAttrInit(   MTX_GRD* restrict p_mutex_guard ,
 /// @param priority Mutex priority (NONE, INHERIT, PROTECT).
 /// @param proc_sharing Share mutex with other processes (PRIVATE, SHARED).
 /// @return Pointer to mutex guard structure if succeeded, NULL otherwise.
-C_MUTEX_GUARD_API C_MUTEX_GUARD_AINLINE MTX_GRD* MutexGuardAttrInitAddr(MTX_GRD* restrict p_mutex_guard ,
-                                                                        const int mutex_type            , 
-                                                                        const int priority              ,
-                                                                        const int proc_sharing          ) {
-    return (MutexGuardAttrInit(p_mutex_guard, mutex_type, priority, proc_sharing) ? NULL : p_mutex_guard);
-}
+C_MUTEX_GUARD_API MTX_GRD* MutexGuardAttrInitAddr(  MTX_GRD* restrict p_mutex_guard ,
+                                                    const int mutex_type            , 
+                                                    const int priority              ,
+                                                    const int proc_sharing          );
 
 /// @brief Initializes mutex.
 /// @param p_mutex_guard Pointer to mutex containing mutex guard structure.
@@ -214,9 +211,7 @@ C_MUTEX_GUARD_API int MutexGuardInit(MTX_GRD* restrict p_mutex_guard);
 /// @brief MutexGuardInit function wrapper.
 /// @param p_mutex_guard Pointer to mutex guard structure.
 /// @return Pointer to given mutex guard structure if succeeded, NULL otherwise.
-C_MUTEX_GUARD_API C_MUTEX_GUARD_AINLINE MTX_GRD* MutexGuardInitAddr(MTX_GRD* restrict p_mutex_guard) {
-    return (MutexGuardInit(p_mutex_guard) ? NULL : p_mutex_guard);
-}
+C_MUTEX_GUARD_API MTX_GRD* MutexGuardInitAddr(MTX_GRD* restrict p_mutex_guard);
 
 /// @brief Locks target mutex.
 /// @param p_mutex_guard Pointer to mutex guard structure.
@@ -235,16 +230,14 @@ C_MUTEX_GUARD_API int MutexGuardLock(   MTX_GRD* p_mutex_guard      ,
 /// @param timeout_ns Target timeout value (if any, in nanoseconds).
 /// @param lock_type Lock type (TR_LOCK, LOCK, TIMED_LOCK, PERIODIC_TIMED_LOCK).
 /// @return Pointer to given mutex guard structure if succeeded, NULL otherwise.
-C_MUTEX_GUARD_API C_MUTEX_GUARD_AINLINE MTX_GRD* MutexGuardLockAddr(MTX_GRD* restrict p_mutex_guard ,
+C_MUTEX_GUARD_API MTX_GRD* MutexGuardLockAddr(MTX_GRD* restrict p_mutex_guard ,
                                                                     void* restrict address          ,
                                                                     const uint64_t timeout_ns       ,
-                                                                    const int lock_type             ) {
-    return (MutexGuardLock(p_mutex_guard, address, timeout_ns, lock_type) ? NULL : p_mutex_guard);
-}
+                                                                    const int lock_type             );
 
 /// @brief Returns address within the program of line in which the current function was called. Meant to be used in macros.
 /// @return Current function calling address.
-C_MUTEX_GUARD_API C_MUTEX_GUARD_NINLINE void* MutexGuardGetFuncRetAddr(void);
+C_MUTEX_GUARD_API C_MUTEX_GUARD_NOINLINE void* MutexGuardGetFuncRetAddr(void);
 
 /// @brief Unlocks target mutex.
 /// @param p_mtx_grd Pointer to mutex guard structure.

--- a/test/src/TestErrorCodes.c
+++ b/test/src/TestErrorCodes.c
@@ -329,6 +329,17 @@ static void TestDestroy()
     }
 }
 
+static void TestSetInternalErrMode()
+{
+    MutexGuardSetInternalErrMode(MTX_GRD_INT_ERR_MGMT_MIN - 1);
+    CU_ASSERT_EQUAL(MutexGuardGetErrorCode(), 1020);
+    CU_ASSERT_STRING_EQUAL(MTX_GRD_GET_LAST_ERR_STR, "Provided invalid internal mutex management mode");
+
+    MutexGuardSetInternalErrMode(MTX_GRD_INT_ERR_MGMT_MAX + 1);
+    CU_ASSERT_EQUAL(MutexGuardGetErrorCode(), 1020);
+    CU_ASSERT_STRING_EQUAL(MTX_GRD_GET_LAST_ERR_STR, "Provided invalid internal mutex management mode");
+}
+
 int CreateErrorCodeTestsSuite()
 {
     CU_pSuite pErrorCodeTestsSuite;
@@ -345,6 +356,7 @@ int CreateErrorCodeTestsSuite()
     ADD_TEST_2_SUITE(pErrorCodeTestsSuite, TestUnlock);
     ADD_TEST_2_SUITE(pErrorCodeTestsSuite, TestAttrDestroy);
     ADD_TEST_2_SUITE(pErrorCodeTestsSuite, TestDestroy);
+    ADD_TEST_2_SUITE(pErrorCodeTestsSuite, TestSetInternalErrMode);
 
     return 0;
 }

--- a/test/src/TestReturnValues.c
+++ b/test/src/TestReturnValues.c
@@ -164,7 +164,7 @@ static void TestDestroy()
 
         pthread_join(thread_0, NULL);
 
-        CU_ASSERT_EQUAL(test_unlock_helper_struct.test_value, -2);
+        CU_ASSERT_EQUAL(test_unlock_helper_struct.test_value, -3);
     }
 
     MTX_GRD_CREATE(test_mtx_grd);

--- a/test/src/TestReturnValues.c
+++ b/test/src/TestReturnValues.c
@@ -173,6 +173,29 @@ static void TestDestroy()
     CU_ASSERT_EQUAL(MutexGuardDestroy(&test_mtx_grd), 0);
 }
 
+static void TestSetInternalErrMode()
+{
+    CU_ASSERT_EQUAL(MutexGuardSetInternalErrMode(MTX_GRD_INT_ERR_MGMT_MIN - 1), -1);
+    CU_ASSERT_EQUAL(MutexGuardSetInternalErrMode(MTX_GRD_INT_ERR_MGMT_MAX + 1), -1);
+
+    CU_ASSERT_EQUAL(MutexGuardSetInternalErrMode(MTX_GRD_INT_ERR_MGMT_KEEP_TRYING),     0);
+    CU_ASSERT_EQUAL(MutexGuardSetInternalErrMode(MTX_GRD_INT_ERR_MGMT_ABORT_ON_ERROR),  0);
+    CU_ASSERT_EQUAL(MutexGuardSetInternalErrMode(MTX_GRD_INT_ERR_MGMT_FORCE_ONE_SHOT),  0);
+}
+
+static void TestGetInternalErrMode()
+{
+    CU_ASSERT_EQUAL(MutexGuardGetInternalErrMode(), MTX_GRD_INT_ERR_MGMT_FORCE_ONE_SHOT);
+
+    for(int int_err_mgmt_mode = MTX_GRD_INT_ERR_MGMT_MIN; int_err_mgmt_mode <= MTX_GRD_INT_ERR_MGMT_MAX; int_err_mgmt_mode++)
+    {
+        MutexGuardSetInternalErrMode(int_err_mgmt_mode);
+        CU_ASSERT_EQUAL(MutexGuardGetInternalErrMode(), int_err_mgmt_mode);
+    }
+
+    MutexGuardSetInternalErrMode(MTX_GRD_INT_ERR_MGMT_FORCE_ONE_SHOT);
+}
+
 int CreateReturnValueTestsSuite()
 {
     CU_pSuite pReturnValueTestsSuite;
@@ -190,6 +213,8 @@ int CreateReturnValueTestsSuite()
     ADD_TEST_2_SUITE(pReturnValueTestsSuite, TestUnlock);
     ADD_TEST_2_SUITE(pReturnValueTestsSuite, TestAttrDestroy);
     ADD_TEST_2_SUITE(pReturnValueTestsSuite, TestDestroy);
+    ADD_TEST_2_SUITE(pReturnValueTestsSuite, TestSetInternalErrMode);
+    ADD_TEST_2_SUITE(pReturnValueTestsSuite, TestGetInternalErrMode);
 
     return 0;
 }

--- a/test/src/main.c
+++ b/test/src/main.c
@@ -24,6 +24,9 @@ int main()
     // Init severity log
     SeverityLogInitWithMask(1000, 0xFF);
 
+    // Modify internal mutex management mode (one shot).
+    MutexGuardSetInternalErrMode(MTX_GRD_INT_ERR_MGMT_FORCE_ONE_SHOT);
+
     // Unit tests
     if(CU_initialize_registry() != CUE_SUCCESS)
         return CU_get_error();


### PR DESCRIPTION
Added ctrl_mutex in MTX_GRD struct definition for non desired deadlocks to be avoided when more than a thread is trying to manipulate the struct in question.